### PR TITLE
Added operator[] support.

### DIFF
--- a/tests/test_iterator.cc
+++ b/tests/test_iterator.cc
@@ -2,6 +2,7 @@
 #  include "config.h"
 #endif
 
+#include <map>
 #include <algorithm>
 #include <chrono>
 #include <cstdint>
@@ -112,6 +113,47 @@ void FilledTableIncrementItems() {
     }
 }
 
+ValType ConstRead(const Table& t, KeyType key) {
+  return t[key];
+}
+
+void IndexOperatorTest() {
+  uint64_t seed =
+      std::chrono::system_clock::now().time_since_epoch().count();
+  std::cout << "seed = " << seed << std::endl;
+  std::uniform_int_distribution<ValType> v_dist(
+      std::numeric_limits<ValType>::min(),
+      std::numeric_limits<ValType>::max());
+  std::mt19937_64 gen(seed);
+  std::map<KeyType, ValType> reference_map;
+  Table cuckoo_map;
+  Table cuckoo_map2;
+  // loop over keys in [0, size) a few times verify that insertions
+  // into the cuckoo map match insertions into the reference map
+  for (size_t i = 0; i < size * size; i++) {
+    KeyType index = i % size;
+    ValType val = v_dist(gen);
+    // store
+    reference_map[index] = val;
+    cuckoo_map[index] = val;
+
+    // load
+    ValType cuckoo_read = cuckoo_map[index];
+    EXPECT_EQ(reference_map[index], cuckoo_read);
+    // const load
+    cuckoo_read = ConstRead(cuckoo_map, index);
+    EXPECT_EQ(reference_map[index], cuckoo_read);
+
+    // store from reference
+    cuckoo_map2[index] = (ValType)cuckoo_map[index]; 
+    EXPECT_EQ((ValType)cuckoo_map[index], (ValType)cuckoo_map2[index]);
+
+    // aliased store
+    cuckoo_map2[index] = (ValType)cuckoo_map2[index];
+    EXPECT_EQ((ValType)cuckoo_map[index], (ValType)cuckoo_map2[index]);
+  }
+}
+
 int main() {
     iter_env = new IteratorEnvironment;
     std::cout << "Running EmptyTableBeginEndIterator" << std::endl;
@@ -122,4 +164,6 @@ int main() {
     FilledTableIterForwards();
     std::cout << "Running FilledTableIncrementItems" << std::endl;
     FilledTableIncrementItems();
+    std::cout << "Running IndexOperatorTest" << std::endl;
+    IndexOperatorTest();
 }


### PR DESCRIPTION
- It is documented that find() and insert() are faster, but this exists
  mainly for convenience.
- The performance of operator[] is basically just as fast as calling
  find/insert for queries and insertions. Update may be slower since updates
  are performed by
  
  ```
    // a unified update/insert will be nice. upsert is not doing
    // anything particularly different from this.
    // and this is currently biased towards inserting a new value
    // than updating an existing value
    while (!owner->insert(key, value) &&
           !owner->update(key, value));
  ```
  
  Note that this implementation here is not exactly STL compliant.
  To maintain performance and avoid hitting the hash table too many
  times, The reference object is _lazy_. In other words,
  - operator[] does not actually perform an insert. It returns a
    reference object pointing to the requested key.
  - On table[i] = val // reference::operator=(mapped_type)
    an insert / update is called, and the reference becomes eager.
  - On val = table[i] // operator mapped_type()
    an find / insert is called and the reference becomes eager.
  - On table[i](i.e. no operation performed), the destructor is called
    immediately (reference::~reference()) in which case
    insert(key, mapped_type()) is called.
  
  Thus, with normal usage, this should behave pretty much exactly like
  a regular reference. However, where issues might occur is when the
  lifetime of the reference exceeds its usual lifespan.
  
  auto i = table[i]
  
  in which case the lifetime of reference object is extended beyond
  what we would like it to be causing issues. To avoid this issue,
  the above is banned. By making the default constructor,
  copy constructor, and assignment operator of the reference object
  private, the above will cause a compilation error.
  
  Though that means that annoyingly,
  
  table[i] = table[j]
  
  will cause a compilation error.
- Having a fused find/insert and a fused insert/update will help make
  the operator[] implementation be _much_ nicer avoiding the silly lazy
  reference issue.
  
  i.e. what will be nice to have is:
  
   // returns mapped value if key exists, or if key does not exist,
  // inserts (key, value) and return value.
  // equivalent to:
  // \code
  //   while(1) {
  //     mapped_type qval;
  //     if (find(key, qval)) return qval;
  //     else if (insert(key, value)) return value;
  //   }
  // \endcode
  mapped_type find_or_insert(key_type key, mapped_type value)
  
  and
  
  // Equivalent to:
  // \code
  //  while (!owner->insert(key, value) &&
  //         !owner->update(key, value));
  // \endcode
  //
  // or,
  //
  // \code
  // upsert(key, [](auto i){return i;}, value);
  // \endcode
  
  (though the upsert is not exactly faster than the while loop)
  mapped_type insert_or_update(key_type key, mapped_type value)
- Changed the update functions to templatize around the Updater. This
  is generally faster since that permits lambda to be inlined rather type
  erased through the std::function.
