### PR TITLE
add instructions to install the requirement in ubuntu

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,10 @@ This library has been tested on Mac OSX >= 10.8 and Ubuntu >= 12.04.
 
 It compiles with clang++ >= 3.1 and g++ >= 4.7, however we strongly suggest
 using the latest versions of both compilers, as they have greatly improved
-support for atomic operations. Building the library requires the autotools.
+support for atomic operations. Building the library requires the
+autotools. Install them on Ubuntu
+
+    $ sudo apt-get update && sudo apt-get install build-essential autoconf libtool
 
 Building
 ==========


### PR DESCRIPTION
probably it's a common knowledge that libtool is required for autoconf, but it takes me several minutes to figure it out. so i add an instruction to install the requirements from a clean ubuntu 