### PR TITLE
Improve portability of cuckoohash_map.hh.

### DIFF
--- a/src/cuckoohash_map.hh
+++ b/src/cuckoohash_map.hh
@@ -23,7 +23,6 @@
 #include <thread>
 #include <tuple>
 #include <type_traits>
-#include <unistd.h>
 #include <utility>
 #include <vector>
 
@@ -146,8 +145,7 @@ private:
 
     // number of cores on the machine
     static size_t kNumCores() {
-        static size_t cores = std::thread::hardware_concurrency() == 0 ?
-            sysconf(_SC_NPROCESSORS_ONLN) : std::thread::hardware_concurrency();
+        static size_t cores = std::thread::hardware_concurrency();
         return cores;
     }
 
@@ -324,7 +322,7 @@ private:
     static inline int get_counterid() {
         // counterid stores the per-thread counter index of each thread. Each
         // counter value corresponds to a core on the machine.
-        static __thread int counterid = -1;
+        static thread_local int counterid = -1;
 
         if (counterid < 0) {
             counterid = rand() % kNumCores();

--- a/src/cuckoohash_map.hh
+++ b/src/cuckoohash_map.hh
@@ -954,6 +954,7 @@ private:
     typedef std::array<CuckooRecord, MAX_BFS_PATH_LEN> CuckooRecords;
 
     // b_slot holds the information for a BFS path through the table
+    #pragma pack(push,1)
     struct b_slot {
         // The bucket of the last item in the path
         size_t bucket;
@@ -980,9 +981,11 @@ private:
             : bucket(b), pathcode(p), depth(d) {
             assert(d < MAX_BFS_PATH_LEN);
         }
-    } __attribute__((__packed__));
+    };
+    #pragma pack(pop)
 
     // b_queue is the queue used to store b_slots for BFS cuckoo hashing.
+    #pragma pack(push,1)
     class b_queue {
         // The maximum size of the BFS queue. Note that unless it's less than
         // SLOT_PER_BUCKET^MAX_BFS_PATH_LEN, it won't really mean anything.
@@ -1025,7 +1028,8 @@ private:
         bool full() {
             return increment(last) == first;
         }
-    } __attribute__((__packed__));
+    };
+    #pragma pack(pop)
 
     // slot_search searches for a cuckoo path using breadth-first search. It
     // starts with the i1 and i2 buckets, and, until it finds a bucket with an

--- a/src/cuckoohash_map.hh
+++ b/src/cuckoohash_map.hh
@@ -752,7 +752,7 @@ private:
     inline void check_hashpower(const size_t hp, const size_t lock) const {
         if (get_hashpower() != hp) {
             locks_[lock].unlock();
-            LIBCUCKOO_DBG("hashpower changed\n");
+            LIBCUCKOO_DBG("%s", "hashpower changed\n");
             throw hashpower_changed();
         }
     }
@@ -1674,7 +1674,7 @@ private:
         if (get_hashpower() != current_hp) {
             // Most likely another expansion ran before this one could grab the
             // locks
-            LIBCUCKOO_DBG("another expansion is on-going\n");
+            LIBCUCKOO_DBG("%s", "another expansion is on-going\n");
             return failure_under_expansion;
         }
 
@@ -1748,7 +1748,7 @@ private:
             (!is_expansion && new_hp >= hp)) {
             // Most likely another expansion ran before this one could grab the
             // locks
-            LIBCUCKOO_DBG("another expansion is on-going\n");
+            LIBCUCKOO_DBG("%s", "another expansion is on-going\n");
             return failure_under_expansion;
         }
 

--- a/src/cuckoohash_map.hh
+++ b/src/cuckoohash_map.hh
@@ -150,7 +150,8 @@ private:
     }
 
     // A fast, lightweight spinlock
-    class spinlock {
+    LIBCUCKOO_SQUELCH_PADDING_WARNING
+    class LIBCUCKOO_ALIGNAS(64) spinlock {
         std::atomic_flag lock_;
     public:
         spinlock() {
@@ -169,7 +170,7 @@ private:
             return !lock_.test_and_set(std::memory_order_acquire);
         }
 
-    } __attribute__((aligned(64)));
+    };
 
     typedef enum {
         ok,
@@ -292,7 +293,8 @@ private:
     typedef std::mutex expansion_lock_t;
 
     // cacheint is a cache-aligned atomic integer type.
-    struct cacheint {
+    LIBCUCKOO_SQUELCH_PADDING_WARNING
+    struct LIBCUCKOO_ALIGNAS(64) cacheint {
         std::atomic<size_t> num;
         cacheint(): num(0) {}
         cacheint(size_t x): num(x) {}
@@ -306,7 +308,7 @@ private:
             num = x.num.load();
             return *this;
         }
-    } __attribute__((aligned(64)));
+    };
 
     // Helper methods to read and write hashpower_ with the correct memory
     // barriers

--- a/src/cuckoohash_util.hh
+++ b/src/cuckoohash_util.hh
@@ -4,7 +4,6 @@
 #define _CUCKOOHASH_UTIL_HH
 
 #include <exception>
-#include <pthread.h>
 #include <thread>
 #include <vector>
 #include "cuckoohash_config.hh" // for LIBCUCKOO_DEBUG
@@ -12,7 +11,7 @@
 #if LIBCUCKOO_DEBUG
 #  define LIBCUCKOO_DBG(fmt, ...)                                        \
      fprintf(stderr, "\x1b[32m""[libcuckoo:%s:%d:%lu] " fmt"" "\x1b[0m", \
-             __FILE__,__LINE__, (unsigned long)pthread_self(), __VA_ARGS__)
+             __FILE__,__LINE__, (unsigned long)std::this_thread::get_id(), __VA_ARGS__)
 #else
 #  define LIBCUCKOO_DBG(fmt, ...)  do {} while (0)
 #endif

--- a/src/cuckoohash_util.hh
+++ b/src/cuckoohash_util.hh
@@ -16,6 +16,26 @@
 #  define LIBCUCKOO_DBG(fmt, ...)  do {} while (0)
 #endif
 
+/**
+ * alignas() requires GCC >= 4.9, so we stick with the alignment attribute for
+ * GCC.
+ */
+#ifdef __GNUC__
+#define LIBCUCKOO_ALIGNAS(x) __attribute__((aligned(x)))
+#else
+#define LIBCUCKOO_ALIGNAS(x) alignas(x)
+#endif
+
+/**
+ * At higher warning levels, MSVC produces an annoying warning that alignment
+ * may cause wasted space: "structure was padded due to __declspec(align())".
+ */
+#ifdef _MSC_VER
+#define LIBCUCKOO_SQUELCH_PADDING_WARNING __pragma(warning(suppress : 4324))
+#else
+#define LIBCUCKOO_SQUELCH_PADDING_WARNING
+#endif
+
 // For enabling certain methods based on a condition. Here's an example.
 // ENABLE_IF(some_cond, type, static, inline) method() {
 //     ...

--- a/src/cuckoohash_util.hh
+++ b/src/cuckoohash_util.hh
@@ -10,11 +10,11 @@
 #include "cuckoohash_config.hh" // for LIBCUCKOO_DEBUG
 
 #if LIBCUCKOO_DEBUG
-#  define LIBCUCKOO_DBG(fmt, args...)                                   \
+#  define LIBCUCKOO_DBG(fmt, ...)                                        \
      fprintf(stderr, "\x1b[32m""[libcuckoo:%s:%d:%lu] " fmt"" "\x1b[0m", \
-             __FILE__,__LINE__, (unsigned long)pthread_self(), ##args)
+             __FILE__,__LINE__, (unsigned long)pthread_self(), __VA_ARGS__)
 #else
-#  define LIBCUCKOO_DBG(fmt, args...)  do {} while (0)
+#  define LIBCUCKOO_DBG(fmt, ...)  do {} while (0)
 #endif
 
 // For enabling certain methods based on a condition. Here's an example.


### PR DESCRIPTION
This pull request removes cuckoohash_map.hh's dependence on GCC-specific compiler directives and POSIX.

Note that commit 344b458b exists in both this pull request and pull request 26. Apart from that they are independent.