### PR TITLE
Fix GCC build breakage when defining LIBCUCKOO_THREAD_LOCAL.

### DIFF
--- a/src/cuckoohash_util.hh
+++ b/src/cuckoohash_util.hh
@@ -41,11 +41,17 @@
  * thread_local requires GCC >= 4.8 and is not supported in some clang versions,
  * so we use __thread if thread_local is not supported
  */
-#if ((__GNUC__ && !__clang__ && __GNUC__ == 4 && __GNUC_MINOR__ < 8) || \
-     (__clang__ && !__has_feature(cxx_thread_local)))
-#define LIBCUCKOO_THREAD_LOCAL __thread
-#else
 #define LIBCUCKOO_THREAD_LOCAL thread_local
+#if defined(__clang__)
+#  if !__has_feature(cxx_thread_local)
+#    undef LIBCUCKOO_THREAD_LOCAL
+#    define LIBCUCKOO_THREAD_LOCAL __thread
+#  endif
+#elif defined(__GNUC__)
+#  if __GNUC__ == 4 && __GNUC_MINOR__ < 8
+#    undef LIBCUCKOO_THREAD_LOCAL
+#    define LIBCUCKOO_THREAD_LOCAL __thread
+#  endif
 #endif
 
 // For enabling certain methods based on a condition. Here's an example.


### PR DESCRIPTION
fe3728d5 broke the GCC build like:

In file included from ../../src/cuckoohash_map.hh:30:0,
                 from insert_throughput.cc:24:
../../src/cuckoohash_util.hh:45:34: error: missing binary operator before token "("
      (__clang__ && !__has_feature(cxx_thread_local)))
                                  ^
Under GCC, "__clang__ && !__has_feature(cxx_thread_local)" would evaluate to
"0 && !0(0)", which is syntactically bogus.

This commit rewrites the logic used to define LIBCUCKOO_THREAD_LOCAL such that
__has_feature() is only evaluated when building with Clang.