### PR TITLE
allow libcuckoo to be used with cmake's find_package()

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,13 @@
 cmake_minimum_required(VERSION 3.1.0)
 project(libcuckoo LANGUAGES C CXX)
+
 set(libcuckoo_VERSION_MAJOR 0)
 set(libcuckoo_VERSION_MINOR 2)
+set(libcuckoo_VERSION_PATCH 0)
+
+# put these in the cache so they show up in ccmake
+option (BUILD_EXAMPLES "build example libcuckoo programs")
+option (BUILD_TESTS "build libcuckoo test programs")
 
 # Add the libcuckoo interface target
 add_subdirectory(libcuckoo)

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -7,21 +7,13 @@ target_link_libraries(hellohash libcuckoo)
 add_executable(count_freq count_freq.cc)
 target_link_libraries(count_freq libcuckoo)
 
-add_library(int_str_table STATIC int_str_table.h int_str_table.cc)
-target_link_libraries(int_str_table
-	PUBLIC libcuckoo-c-intf
-	PRIVATE libcuckoo-c-impl
-)
+add_library(int_str_table STATIC int_str_table.cc)
+target_link_libraries(int_str_table libcuckoo)
 
-add_library(blob_blob_table STATIC blob_blob_table.h blob_blob_table.cc)
-target_link_libraries(blob_blob_table
-	PUBLIC libcuckoo-c-intf
-	PRIVATE libcuckoo-c-impl
-)
+add_library(blob_blob_table STATIC blob_blob_table.cc)
+target_link_libraries(blob_blob_table libcuckoo)
 
 add_executable(c_hash c_hash.c)
-target_link_libraries(c_hash
-	PRIVATE int_str_table
-	PRIVATE blob_blob_table
-)
+target_link_libraries(c_hash int_str_table blob_blob_table)
+
 set_property(TARGET c_hash PROPERTY C_STANDARD 99)

--- a/libcuckoo-c/CMakeLists.txt
+++ b/libcuckoo-c/CMakeLists.txt
@@ -1,19 +1,7 @@
-add_library(libcuckoo-c-intf INTERFACE)
-add_library(libcuckoo-c-impl INTERFACE)
-
-# Include relative to the base directory
-target_include_directories(libcuckoo-c-intf INTERFACE
-    $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}>
-    $<INSTALL_INTERFACE:include>
-)
-
-target_include_directories(libcuckoo-c-impl INTERFACE
-    $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}>
-    $<INSTALL_INTERFACE:include>
-)
+add_library(libcuckoo-c INTERFACE)
 
 # Link the implementation to libcuckoo
-target_link_libraries(libcuckoo-c-impl INTERFACE libcuckoo)
+target_link_libraries(libcuckoo-c INTERFACE libcuckoo)
 
 install(
 FILES

--- a/libcuckoo/CMakeLists.txt
+++ b/libcuckoo/CMakeLists.txt
@@ -1,4 +1,21 @@
+# for write_basic_package_version_file()
+include(CMakePackageConfigHelpers)
+
+# we require the use of threads
+set(THREADS_PREFER_PTHREAD_FLAG ON)
+find_package(Threads REQUIRED)
+
+# generate a version for cmake to use with find_package(libcuckoo)
+set (libcuckoo_VERSION "${libcuckoo_VERSION_MAJOR}.${libcuckoo_VERSION_MINOR}")
+set (libcuckoo_VERSION "${libcuckoo_VERSION}.${libcuckoo_VERSION_PATCH}")
+
+# libcuckoo is an interface (all headers) library target
 add_library(libcuckoo INTERFACE)
+
+# tag libcuckoo target with a c++11 feature so that libcuckoo users
+# will have c++11 turned on in their compile when they use this target.
+# XXX: newer cmakes have a "cxx_std_11" feature that could be used
+target_compile_features (libcuckoo INTERFACE cxx_constexpr)
 
 # Include relative to the base directory
 target_include_directories(libcuckoo INTERFACE
@@ -6,18 +23,23 @@ target_include_directories(libcuckoo INTERFACE
     $<INSTALL_INTERFACE:include>
 )
 
-# Enable C++11 for all targets that link with libcuckoo
-if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-    target_compile_options(libcuckoo INTERFACE -std=c++11 -stdlib=libc++)
-elseif(CMAKE_CXX_COMPILER_ID MATCHES "GNU")
-    target_compile_options(libcuckoo INTERFACE -std=gnu++11)
-endif()
-
-# Enable threading for all targets that link with libcuckoo
-set(THREADS_PREFER_PTHREAD_FLAG ON)
-find_package(Threads REQUIRED)
+# switch on threading for all targets that link with libcuckoo
 target_link_libraries(libcuckoo INTERFACE Threads::Threads)
 
+# cmake packaging
+set (libcuckoo_pkgloc "share/cmake/libcuckoo")
+
+write_basic_package_version_file(
+    "libcuckoo-config-version.cmake" VERSION ${libcuckoo_VERSION}
+    COMPATIBILITY AnyNewerVersion)
+
+install(TARGETS libcuckoo EXPORT libcuckoo-targets)
+install(EXPORT libcuckoo-targets
+        DESTINATION ${libcuckoo_pkgloc}
+        FILE "libcuckoo-targets.cmake")
+install(FILES libcuckoo-config.cmake
+              ${CMAKE_CURRENT_BINARY_DIR}/libcuckoo-config-version.cmake
+              DESTINATION ${libcuckoo_pkgloc})
 install(
 FILES
     cuckoohash_config.hh

--- a/libcuckoo/libcuckoo-config.cmake
+++ b/libcuckoo/libcuckoo-config.cmake
@@ -1,0 +1,10 @@
+#
+# libcuckoo-config.cmake
+#
+
+include (CMakeFindDependencyMacro)
+
+set(THREADS_PREFER_PTHREAD_FLAG ON)
+find_dependency(Threads)
+
+include ("${CMAKE_CURRENT_LIST_DIR}/libcuckoo-targets.cmake")

--- a/tests/unit-tests/CMakeLists.txt
+++ b/tests/unit-tests/CMakeLists.txt
@@ -1,8 +1,5 @@
-add_library(int_int_table STATIC int_int_table.h int_int_table.cc)
-target_link_libraries(int_int_table
-	PUBLIC libcuckoo-c-intf
-	PRIVATE libcuckoo-c-impl
-)
+add_library(int_int_table STATIC int_int_table.cc)
+target_link_libraries(int_int_table libcuckoo)
 
 add_executable(unit_tests
     test_constructor.cc

--- a/tests/universal-benchmark/CMakeLists.txt
+++ b/tests/universal-benchmark/CMakeLists.txt
@@ -1,8 +1,4 @@
-add_executable(universal_benchmark
-    universal_benchmark.cc
-    universal_gen.hh
-    universal_table_wrapper.hh
-)
+add_executable(universal_benchmark universal_benchmark.cc)
 
 target_link_libraries(universal_benchmark
     PRIVATE test_util


### PR DESCRIPTION
install a cmake config for libcuckoo so that users can cleanly
access us with find_package(libcuckoo).  external apps can
access like this:

find_package(libcuckoo CONFIG REQUIRED)
add_executable(doit doit.cc)
target_link_libraries(doit libcuckoo)

the libcuckoo target's properties will cause doit to compile with 
the correct -I's, enable threading, and turn on c++11.

while I'm here, clean up CMakeLists.txt files:
 - add BUILD_EXAMPLES and BUILD_TESTS as cache variables so that
   they show up in ccmake (there is prob more than could be added)
 - remove unneeded cuckoo-c targets... just use the libcuckoo target instead
 - don't put header files in add_executable lists
    (cmake's auto depend features will catch changes to files
     that are #included)
 - use target_compile_features to kick on c++11 instead of trying
   to directly set compiler flags
