### PR TITLE
Fix friend declarations that refer to templates, not classes.

### DIFF
--- a/libcuckoo/cuckoohash_map.hh
+++ b/libcuckoo/cuckoohash_map.hh
@@ -2429,7 +2429,7 @@ public:
     // A manager for all the locks we took on the table.
     AllLocksManager all_locks_manager_;
 
-    friend class cuckoohash_map;
+    friend class cuckoohash_map<Key, T, Hash, KeyEqual, Allocator, SLOT_PER_BUCKET>;
 
     friend std::ostream &operator<<(std::ostream &os, const locked_table &lt) {
       os << lt.buckets();

--- a/libcuckoo/libcuckoo_bucket_container.hh
+++ b/libcuckoo/libcuckoo_bucket_container.hh
@@ -84,7 +84,7 @@ public:
     bool &occupied(size_type ind) { return occupied_[ind]; }
 
   private:
-    friend class libcuckoo_bucket_container;
+    friend class libcuckoo_bucket_container<Key, T, Allocator, Partial, SLOT_PER_BUCKET>;
 
     using storage_value_type = std::pair<Key, T>;
 


### PR DESCRIPTION
This commit addresses a couple of PW.BAD_FRIEND_DECL parse warnings thrown up by
Coverity.

Apparently a friend declaration that refers to a template (as opposed to a type)
is not legal C++. Who knew? Neither GCC nor MSVC seem to care. Anyhow, this
commit corrects the error by specifying all the necessary template parameters to
make the declarations refer to types.