### PR TITLE
Rename variable in cuckoopath_move() to avoid shadowing warning.

### DIFF
--- a/libcuckoo/cuckoohash_map.hh
+++ b/libcuckoo/cuckoohash_map.hh
@@ -1366,10 +1366,10 @@ private:
       // cuckoopath_search found empty isn't empty anymore, we unlock them
       // and return false. Otherwise, the bucket is empty and insertable,
       // so we hold the locks and return true.
-      const size_type bucket = cuckoo_path[0].bucket;
-      assert(bucket == b.i1 || bucket == b.i2);
+      const size_type bucket_i = cuckoo_path[0].bucket;
+      assert(bucket_i == b.i1 || bucket_i == b.i2);
       b = lock_two(hp, b.i1, b.i2, TABLE_MODE());
-      if (!buckets_[bucket].occupied(cuckoo_path[0].slot)) {
+      if (!buckets_[bucket_i].occupied(cuckoo_path[0].slot)) {
         return true;
       } else {
         b.unlock();


### PR DESCRIPTION
When compiling with -Wshadow enabled, GCC 8 complains:
libcuckoo/cuckoohash_map.hh:1369:23: warning: declaration of ‘bucket’ shadows a previous local [-Wshadow]
       const size_type bucket = cuckoo_path[0].bucket;
                       ^~~~~~
libcuckoo/cuckoohash_map.hh:1002:44: note: shadowed declaration is here
   using bucket = typename buckets_t::bucket;
                                            ^
This commit renames "bucket" to "bucket_i" within cuckoopath_move() to silence
this warning.

Closes: #104