### PR TITLE
Fix generated JSON entity in universal_benchmark

### DIFF
--- a/tests/universal-benchmark/universal_benchmark.cc
+++ b/tests/universal-benchmark/universal_benchmark.cc
@@ -355,7 +355,7 @@ int main(int argc, char **argv) {
     "key": "%s",
     "key_size": "%zu",
     "value": "%s",
-    "value_size", "%zu",
+    "value_size": "%zu",
     "table": "%s",
     "output": {
         "total_ops": {


### PR DESCRIPTION
Initial version of `universal_benchmark.cc` generates a broken JSON entity when running universal_benchmark.
This patch fixes the issue.
