### PR TITLE
Basic fix for std::is_pod deprecation in C++20

### DIFF
--- a/libcuckoo/cuckoohash_map.hh
+++ b/libcuckoo/cuckoohash_map.hh
@@ -705,7 +705,9 @@ private:
   // true if the key is small and simple, which means using partial keys for
   // lookup would probably slow us down
   static constexpr bool is_simple() {
-    return std::is_pod<key_type>::value && sizeof(key_type) <= 8;
+    return std::is_standard_layout<key_type>::value &&
+           std::is_trivial<key_type>::value &&
+           sizeof(key_type) <= 8;
   }
 
   // Whether or not the data is nothrow-move-constructible.


### PR DESCRIPTION
Retains C++11 compatibility.