### PR TITLE
replace `std::aligned_storage` with `AlignedStorageType`

### DIFF
--- a/libcuckoo/bucket_container.hh
+++ b/libcuckoo/bucket_container.hh
@@ -49,7 +49,7 @@ public:
 
   /*
    * The bucket type holds SLOT_PER_BUCKET key-value pairs, along with their
-   * partial keys and occupancy info. It uses aligned_storage arrays to store
+   * partial keys and occupancy info. It uses AlignedStorageType arrays to store
    * the keys and values to allow constructing and destroying key-value pairs
    * in place. The lifetime of bucket data should be managed by the container.
    * It is the user's responsibility to confirm whether the data they are
@@ -99,8 +99,8 @@ public:
           static_cast<void *>(&values_[ind]));
     }
 
-    std::array<typename std::aligned_storage<sizeof(storage_value_type),
-                                             alignof(storage_value_type)>::type,
+    std::array<AlignedStorageType<sizeof(storage_value_type),
+                                  alignof(storage_value_type)>,
                SLOT_PER_BUCKET>
         values_;
     std::array<partial_t, SLOT_PER_BUCKET> partials_;

--- a/libcuckoo/cuckoohash_util.hh
+++ b/libcuckoo/cuckoohash_util.hh
@@ -138,6 +138,16 @@ enum class UpsertContext {
   ALREADY_EXISTED,
 };
 
+/**
+ * The replacement of `std::aligned_storage`
+ * which has been deprecated in c++23.
+ */
+template<size_t Len, size_t Align>
+union AlignedStorageType {
+    unsigned char data_[Len];
+    alignas(Align) struct {} empty_;
+};
+
 namespace internal {
 
 // Used to invoke the \ref uprase_fn functor with or without an \ref


### PR DESCRIPTION
Hi, since the `std::aligned_storage` has been deprecated in C++23 for some reason.
I have re-implement it as `AlignedStorageType` to replace the STL one.
For people who wanna use libcuckoo in C++23 without error message.

See also www.open-std.org/jtc1/sc22/wg21/docs/papers/2022/n4907.pdf
