### PR TITLE
Set cmake minimum required version to 3.5 to allow build with CMake 4

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1.0)
+cmake_minimum_required(VERSION 3.5.0)
 project(libcuckoo
     VERSION 0.3.1
     LANGUAGES C CXX)


### PR DESCRIPTION
CMake 4 removed compatibility with CMake < 3.5, preventing us from using libcuckoo. Let's just raise to 3.5 which is really old by now to stay forward compatible.