### PR TITLE
Use memory_order_acquire for spinlock instead of acq_rel

### DIFF
--- a/libcuckoo/cuckoohash_map.hh
+++ b/libcuckoo/cuckoohash_map.hh
@@ -833,14 +833,14 @@ private:
     }
 
     void lock() noexcept {
-      while (lock_.test_and_set(std::memory_order_acq_rel))
+      while (lock_.test_and_set(std::memory_order_acquire))
         ;
     }
 
     void unlock() noexcept { lock_.clear(std::memory_order_release); }
 
     bool try_lock() noexcept {
-      return !lock_.test_and_set(std::memory_order_acq_rel);
+      return !lock_.test_and_set(std::memory_order_acquire);
     }
 
     counter_type &elem_counter() noexcept { return elem_counter_; }


### PR DESCRIPTION
## Summary

- Use `memory_order_acquire` for `lock()` and `try_lock()` instead of `memory_order_acq_rel`
- The standard spinlock pattern is acquire on lock, release on unlock. The release semantics on the lock path are unnecessary — when acquiring a lock, you need to ensure subsequent operations stay after the acquisition (acquire), but there is nothing to release at that point
- This restores the original behavior from the initial commit (e57758e, Jan 2014). The change to `acq_rel` was introduced in 8530b8a (Dec 2016) with the rationale "since test-and-set is both a read and a write operation, it should [use acq_rel]" — however the "write" in test-and-set is the lock flag itself, which does not need release semantics during acquisition

## Impact

- **x86**: No change. `test_and_set` compiles to `XCHG` which is a full barrier regardless of the memory order specified
- **ARM/POWER**: Removes an unnecessary barrier instruction. `acq_rel` generates both an acquire and release barrier, while `acquire` generates only the acquire barrier. This is a measurable improvement on weakly-ordered architectures

## Context

This aligns with the three open PRs improving the spinlock (#147, #149, #158) and the discussion in issue #146.

## Test plan

- [x] All existing unit tests pass
- [x] Consistent with the acquire/release pattern used by the existing `unlock()` method